### PR TITLE
Error details

### DIFF
--- a/src/http/dispatch/dispatch-by-accepted.handler.ts
+++ b/src/http/dispatch/dispatch-by-accepted.handler.ts
@@ -65,7 +65,7 @@ export function dispatchByAccepted<TMeans extends HttpMeans>(
     const handler = negotiator(accept);
 
     if (!handler) {
-      return Promise.reject(new HttpError(406, 'Not Acceptable'));
+      return Promise.reject(new HttpError(406));
     }
 
     addResponseHeader(response, 'Vary', 'Accept');

--- a/src/http/dispatch/dispatch-by-language.handler.ts
+++ b/src/http/dispatch/dispatch-by-language.handler.ts
@@ -60,7 +60,7 @@ export function dispatchByLanguage<TMeans extends HttpMeans>(
     const handler = negotiator(acceptLanguage);
 
     if (!handler) {
-      return Promise.reject(new HttpError(406, 'Not Acceptable'));
+      return Promise.reject(new HttpError(406));
     }
 
     addResponseHeader(response, 'Vary', 'Accept-Language');

--- a/src/http/http-error.spec.ts
+++ b/src/http/http-error.spec.ts
@@ -6,7 +6,10 @@ describe('HttpError', () => {
       expect(new HttpError(404).message).toBe('404');
     });
     it('contains status code and message', () => {
-      expect(new HttpError(404, 'Not Found').message).toBe('404 Not Found');
+      expect(new HttpError(404, { statusMessage: 'Not Found' }).message).toBe('404 Not Found');
+    });
+    it('contains explicit message', () => {
+      expect(new HttpError(404, { message: 'TEST' }).message).toBe('TEST');
     });
   });
 });

--- a/src/http/http-error.ts
+++ b/src/http/http-error.ts
@@ -13,16 +13,82 @@
 export class HttpError extends Error {
 
   /**
+   * HTTP status message.
+   */
+  readonly statusMessage?: string;
+
+  /**
+   * Error details.
+   *
+   * This will be displayed on error page in addition to error code.
+   */
+  readonly details?: string;
+
+  /**
+   * Arbitrary error reason.
+   *
+   * This is another error typically.
+   */
+  readonly reason?: any;
+
+  /**
    * Constructs HTTP status error.
    *
    * @param statusCode  HTTP status code.
-   * @param statusMessage  HTTP status message.
+   * @param options  HTTP error options.
    */
-  constructor(
-      readonly statusCode: number,
-      readonly statusMessage?: string,
-  ) {
-    super(statusMessage ? `${statusCode} ${statusMessage}` : `${statusCode}`);
+  constructor(readonly statusCode: number, options: HttpError.Options = {}) {
+    super(httpErrorMessage(statusCode, options));
+    this.statusMessage = options.statusMessage;
+    this.details = options.details;
+    this.reason = options.reason;
+  }
+
+}
+
+function httpErrorMessage(
+    statusCode: number,
+    {
+      statusMessage,
+      message = statusMessage ? `${statusCode} ${statusMessage}` : `${statusCode}`,
+    }: HttpError.Options,
+): string {
+  return message;
+}
+
+export namespace HttpError {
+
+  /**
+   * Options for {@link HttpError HTTP error} construction.
+   */
+  export interface Options {
+
+    /**
+     * HTTP status message.
+     */
+    readonly statusMessage?: string,
+
+    /**
+     * Error message.
+     *
+     * @default Constructed by status code and status message.
+     */
+    readonly message?: string;
+
+    /**
+     * Error details.
+     *
+     * This will be displayed on error page in addition to error code.
+     */
+    readonly details?: string;
+
+    /**
+     * Arbitrary error reason.
+     *
+     * This is another error typically.
+     */
+    readonly reason?: any;
+
   }
 
 }

--- a/src/http/http-listener.spec.ts
+++ b/src/http/http-listener.spec.ts
@@ -43,9 +43,19 @@ describe('httpListener', () => {
 
     expect(response.statusCode).toBe(404);
     expect(response.statusMessage).toBe('Not Found');
+    expect(response.headers['content-type']).toContain('text/html');
     expect(await response.body()).toContain('ERROR 404');
   });
-  it('does not respond when handler not responding ad no default handler', async () => {
+  it('responds with `404` status and JSON when handler not responding and JSON expected', async () => {
+    server.listener.mockImplementation(httpListener({ log: suppressedLog }, noop));
+
+    const response = await server.get('/', { headers: { accept: 'application/json' } });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.statusMessage).toBe('Not Found');
+    expect(JSON.parse(await response.body())).toEqual({ error: { code: 404, message: 'Not Found' } });
+  });
+  it('does not respond when handler not responding and no default handler', async () => {
 
     const listener = httpListener({ defaultHandler: false }, noop);
 
@@ -72,9 +82,21 @@ describe('httpListener', () => {
     expect(response.statusMessage).toBe('Internal Server Error');
     expect(await response.body()).toContain('ERROR 500');
   });
+  it('responds with `500` status and JSON when handler throws error and JSON expected', async () => {
+
+    const error = new Error('test');
+
+    server.listener.mockImplementation(httpListener({ log: suppressedLog }, () => { throw error; }));
+
+    const response = await server.get('/test', { headers: { accept: 'application/json' } });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.statusMessage).toBe('Internal Server Error');
+    expect(JSON.parse(await response.body())).toEqual({ error: { code: 500, message: 'Internal Server Error' } });
+  });
   it('responds with error status when handler throws error', async () => {
 
-    const error = new HttpError(403);
+    const error = new HttpError(403, { details: 'No Go' });
 
     server.listener.mockImplementation(httpListener({ log: suppressedLog }, () => { throw error; }));
 
@@ -82,7 +104,26 @@ describe('httpListener', () => {
 
     expect(response.statusCode).toBe(403);
     expect(response.statusMessage).toBe('Forbidden');
-    expect(await response.body()).toContain('ERROR 403');
+
+    const body = await response.body();
+
+    expect(body).toContain('ERROR 403 Forbidden');
+    expect(body).toContain('No Go');
+  });
+  it('responds with error status and JSON when handler throws error and JSON expected', async () => {
+
+    const error = new HttpError(403, { details: 'No Go' });
+
+    server.listener.mockImplementation(httpListener({ log: suppressedLog }, () => { throw error; }));
+
+    const response = await server.get('/test', { headers: { accept: 'application/json' } });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.statusMessage).toBe('Forbidden');
+
+    const body = await response.body();
+
+    expect(JSON.parse(body)).toEqual({ error: { code: 403, message: 'Forbidden', details: 'No Go' } });
   });
   it('invokes provided default handler when handler not responding', async () => {
 

--- a/src/http/http-listener.ts
+++ b/src/http/http-listener.ts
@@ -228,7 +228,7 @@ function defaultHttpHandler<TMeans extends HttpMeans>(
   }
   return defaultHandler !== true
       ? defaultHandler
-      : () => Promise.reject(new HttpError(404, 'Not Found'));
+      : () => Promise.reject(new HttpError(404));
 }
 
 /**
@@ -258,11 +258,25 @@ function httpErrorHandler<TMeans extends HttpMeans>(
 function logHttpError(
     { request, log, error }: RequestContext<HttpMeans & ErrorMeans>,
 ): void {
+
+  const report: any[] = [`[${request.method} ${request.url}]`];
+
   if (error instanceof HttpError) {
-    log.error(`[${request.method} ${request.url}]`, `ERROR ${error.message}`);
+    report.push(error.message);
+
+    const { details, reason } = error;
+
+    if (details) {
+      report.push(details);
+    }
+    if (reason) {
+      report.push(reason);
+    }
   } else {
-    log.error(`[${request.method} ${request.url}]`, error);
+    report.push(error);
   }
+
+  log.error(...report);
 }
 
 /**

--- a/src/http/middleware.spec.ts
+++ b/src/http/middleware.spec.ts
@@ -55,7 +55,7 @@ describe('middleware', () => {
     expect(ware).toHaveBeenCalledTimes(1);
   });
   it('allows middleware to error', async () => {
-    ware.mockImplementation((_request, _response, next) => next(new HttpError(503, 'Custom Error')));
+    ware.mockImplementation((_request, _response, next) => next(new HttpError(503, { statusMessage: 'Custom Error' })));
 
     server.listener.mockImplementation(httpListener(
         {

--- a/src/http/render/render-http-error.handler.ts
+++ b/src/http/render/render-http-error.handler.ts
@@ -5,6 +5,7 @@
 import { ErrorMeans, RequestContext } from '../../core';
 import { HttpError } from '../http-error';
 import { HttpMeans } from '../http.means';
+import { escapeHtml } from '../util';
 import { RenderMeans } from './render.means';
 import { Rendering } from './rendering.capability';
 
@@ -18,24 +19,37 @@ function renderHttpErrorPage(
       renderHtml,
     }: RequestContext<HttpMeans & RenderMeans & ErrorMeans>,
 ): void {
+
+  let message: string;
+  let details: string;
+
   if (error instanceof HttpError) {
     response.statusCode = error.statusCode;
-    if (error.statusMessage) {
-      response.statusMessage = error.statusMessage;
+
+    const { statusMessage } = error;
+
+    if (statusMessage) {
+      response.statusMessage = statusMessage;
+      message = ` ${escapeHtml(statusMessage)}`;
     }
+    message = escapeHtml(statusMessage);
+    details = `<p>${escapeHtml(error.details)}</p>`;
   } else {
     response.statusCode = 500;
-    response.statusMessage = 'Internal Server Error';
+    message = ' Internal Server Error';
+    details = '';
   }
 
   renderHtml(
       `<!DOCTYPE html>
 <html lang="en">
 <head>
-<title>ERROR ${response.statusCode} ${response.statusMessage}</title>
+<title>ERROR ${response.statusCode}${message}</title>
 </head>
 <body>
-<h1><strong>ERROR ${response.statusCode}</strong> ${response.statusMessage}</h1>
+<h1><strong>ERROR ${response.statusCode}</strong>${message}</h1>
+<hr/>
+${details}
 </body>
 </html>
 `,

--- a/src/http/request/form-decoding.capability.spec.ts
+++ b/src/http/request/form-decoding.capability.spec.ts
@@ -106,6 +106,6 @@ describe('FormDecoding', () => {
     );
 
     expect(response.statusCode).toBe(415);
-    expect(response.statusMessage).toBe('application/x-www-form-urlencoded request expected');
+    expect(await response.body()).toContain('application/x-www-form-urlencoded request expected');
   });
 });

--- a/src/http/request/form-decoding.capability.ts
+++ b/src/http/request/form-decoding.capability.ts
@@ -74,7 +74,7 @@ class FormDecodingCapability<TInput extends HttpMeans, TBody>
     const { 'content-type': contentType = Text__MIME } = request.headers;
 
     if (!URL_ENCODED_MIMES[contentType]) {
-      return Promise.reject(new HttpError(415, `${URLEncoded__MIME} request expected`));
+      return Promise.reject(new HttpError(415, { details: `${URLEncoded__MIME} request expected` }));
     }
 
     const params = new URLSearchParams(await readAll(request));

--- a/src/http/request/json-parsing.capability.spec.ts
+++ b/src/http/request/json-parsing.capability.spec.ts
@@ -114,10 +114,11 @@ describe('JsonParsing', () => {
     );
 
     expect(response.statusCode).toBe(415);
-    expect(response.statusMessage).toBe('application/json request expected');
+    expect(await response.body()).toContain('application/json request expected');
   });
   it('responds with 400 (Bad Request) with non-JSON content', async () => {
 
+    const errorSpy = jest.spyOn(suppressedLog, 'error');
     const response = await server.post(
         '/test',
         'param1=value1&param2=value2',
@@ -127,6 +128,12 @@ describe('JsonParsing', () => {
     );
 
     expect(response.statusCode).toBe(400);
-    expect(response.statusMessage).toContain('Unexpected token');
+    expect(await response.body()).toContain('Malformed JSON');
+    expect(errorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        '400',
+        'Malformed JSON',
+        expect.objectContaining({ message: expect.stringContaining('Unexpected token') }),
+    );
   });
 });

--- a/src/http/request/json-parsing.capability.ts
+++ b/src/http/request/json-parsing.capability.ts
@@ -81,7 +81,7 @@ class JsonParsingCapability<TInput extends HttpMeans, TBody>
     const { 'content-type': contentType = Text__MIME } = request.headers;
 
     if (!JSON_MIMES[contentType]) {
-      return Promise.reject(new HttpError(415, `${JSON__MIME} request expected`));
+      return Promise.reject(new HttpError(415, { details: `${JSON__MIME} request expected` }));
     }
 
     let json: any;
@@ -90,7 +90,7 @@ class JsonParsingCapability<TInput extends HttpMeans, TBody>
     try {
       json = JSON.parse(text);
     } catch (e) {
-      return Promise.reject(new HttpError(400, e.message));
+      return Promise.reject(new HttpError(400, { details: 'Malformed JSON', reason: e }));
     }
 
     return requestExtension<TMeans, RequestBodyMeans<TBody>>({

--- a/src/http/util/escape-html.spec.ts
+++ b/src/http/util/escape-html.spec.ts
@@ -1,0 +1,10 @@
+import { escapeHtml } from './escape-html';
+
+describe('escapeHtml', () => {
+  it('escapes HTML-unsafe symbols', () => {
+    expect(escapeHtml('<b&b>')).toEqual('&lt;b&amp;b&gt;');
+  });
+  it('escapes subsequent HTML-unsafe symbols', () => {
+    expect(escapeHtml('<<<=>>>')).toEqual('&lt;&lt;&lt;=&gt;&gt;&gt;');
+  });
+});

--- a/src/http/util/escape-html.ts
+++ b/src/http/util/escape-html.ts
@@ -1,0 +1,30 @@
+/**
+ * @packageDocumentation
+ * @module @hatsy/hatsy
+ */
+/**
+ * @internal
+ */
+const htmlUnsafe: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+};
+
+/**
+ * @internal
+ */
+function replaceHtmlUnsafe(char: string): string {
+  return htmlUnsafe[char];
+}
+
+/**
+ * Escapes HTML-unsafe entities.
+ *
+ * @param text  Text to escape.
+ *
+ * @returns HTML-escaped text.
+ */
+export function escapeHtml(text: string | null | undefined): string {
+  return text ? text.replace(/[&<>]/g, replaceHtmlUnsafe) : '';
+}

--- a/src/http/util/index.ts
+++ b/src/http/util/index.ts
@@ -3,4 +3,5 @@
  * @module @hatsy/hatsy
  */
 export * from './add-response-header';
+export * from './escape-html';
 export * from './mime';


### PR DESCRIPTION
- Add details to `HttpError`
- Report error details on HTML error page.
- Respond with JSON error page when expected.