### PR TITLE
Error dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,14 @@ The following dispatcher implemented:
 
 - [dispatchByAccepted] dispatches accordingly to [content negotiation] based on [Accept] request header.
 - [dispatchByLanguage] dispatches accordingly to [content negotiation] based on [Accept-Language] request header.
-- [dispatchByMethod] dispatches accordingly to HTTP request method.   
+- [dispatchByMethod] dispatches accordingly to HTTP request method.
+- [dispatchError] dispatches request processing error.   
 
 [dispatchByAccepted]: https://hatsyjs.github.io/hatsy/modules/@hatsy_hatsy.html#dispatchByAccepted
 [dispatchByLanguage]: https://hatsyjs.github.io/hatsy/modules/@hatsy_hatsy.html#dispatchByLanguage
-[dispatchByMethod]: https://hatsyjs.github.io/hatsy/modules/@hatsy_hatsy.html#dispatchByMethod  
+[dispatchByMethod]: https://hatsyjs.github.io/hatsy/modules/@hatsy_hatsy.html#dispatchByMethod
+[dispatchError]:  https://hatsyjs.github.io/hatsy/modules/@hatsy_hatsy_core.html#dispatchError
+  
 [content negotiation]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation
 [Accept]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
 [Accept-Language]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language  

--- a/src/core/dispatch-error.ts
+++ b/src/core/dispatch-error.ts
@@ -1,0 +1,27 @@
+/**
+ * @packageDocumentation
+ * @module @hatsy/hatsy/core
+ */
+import type { ErrorMeans } from './error.means';
+import type { RequestHandler } from './request-handler';
+import { requestExtension } from './request-modification';
+
+/**
+ * Dispatches request processing error.
+ *
+ * Processes request with the given handler. If processing fails, processes error with the given `onError` one.
+ *
+ * @typeParam TMeans  Request processing means.
+ * @param onError  Error processing handler.
+ * @param handler  Request processing handler to process the original request with.
+ *
+ * @returns New request processing handler.
+ */
+export function dispatchError<TMeans>(
+    onError: RequestHandler<TMeans & ErrorMeans>,
+    handler: RequestHandler<TMeans>,
+): RequestHandler<TMeans> {
+  return context => context
+      .next(handler)
+      .catch(error => context.next<ErrorMeans>(onError, requestExtension({ error })));
+}

--- a/src/core/error.means.ts
+++ b/src/core/error.means.ts
@@ -7,12 +7,14 @@
  *
  * A context with these means is created once error is thrown by one of the handlers right before passing it to error
  * handler.
+ *
+ * @typeParam TError  Error type.
  */
-export interface ErrorMeans {
+export interface ErrorMeans<TError = any> {
 
   /**
    * Error thrown.
    */
-  readonly error: any;
+  readonly error: TError;
 
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
+export * from './dispatch-error';
 export * from './error.means';
 export * from './request-body.means';
 export * from './request-capability';


### PR DESCRIPTION
- Add `dispatchError()` request processing error dispatcher.
- Add error type parameter to `ErrorMeans`. `any` by default.
